### PR TITLE
Read only packages mount

### DIFF
--- a/src/portscan-packager.adb
+++ b/src/portscan-packager.adb
@@ -182,6 +182,7 @@ package body PortScan.Packager is
                       HT.USS (all_ports (seq_id).port_variant) & "-" & pkgvers & arc_ext;
          built_loc  : constant String := rootdir & newpkgdir & "/" & pkgarchive;
          final_loc  : constant String := realpkgdir & "/All/" & pkgarchive;
+         link_loc   : constant String := realpkgdir & "/Latest/" & pkgarchive;
          mv_program : constant String := sysroot & "/bin/mv ";
          mv_command : constant String := mv_program & " " & built_loc & " " & final_loc;
          cmd_output : HT.Text;
@@ -194,9 +195,12 @@ package body PortScan.Packager is
                TIO.Put_Line (log_handle, "Message: " & HT.USS (cmd_output));
             end if;
             if still_good and then namebase = "pkg" then
+               if DIR.Exists (link_loc) then
+                  DIR.Delete_File (link_loc);
+               end if;
                still_good := Unix.create_symlink
                  (actual_file => "../All/" & pkgarchive,
-                  link_to_create => realpkgdir & "/Latest/" & pkgarchive);
+                  link_to_create => link_loc);
             end if;
          end if;
       end move_it_outside_sysroot;

--- a/src/replicant.adb
+++ b/src/replicant.adb
@@ -1050,7 +1050,7 @@ package body Replicant is
       folder_access (location (slave_base, home), lock);
       folder_access (location (slave_base, root), lock);
 
-      mount_nullfs (mount_target (packages),  location (slave_base, packages),  mode => readwrite);
+      mount_nullfs (mount_target (packages),  location (slave_base, packages),  mode => readonly);
       mount_nullfs (mount_target (distfiles), location (slave_base, distfiles), mode => readwrite);
 
       if need_procfs or else

--- a/src/unix.adb
+++ b/src/unix.adb
@@ -325,14 +325,14 @@ package body Unix is
    --------------------------------------------------------------------------------------------
    --  create_symlink
    --------------------------------------------------------------------------------------------
-   function create_symlink (actual_file : String; destination : String) return Boolean
+   function create_symlink (actual_file : String; link_to_create : String) return Boolean
    is
       use type IC.int;
       path1  : IC.char_array := IC.To_C (actual_file);
-      path2  : IC.char_array := IC.To_C (destination);
+      path2  : IC.char_array := IC.To_C (link_to_create);
       result : IC.int;
    begin
-      if actual_file = "" or else destination = "" then
+      if actual_file = "" or else link_to_create = "" then
          return False;
       end if;
       result := symlink (path1, path2);

--- a/src/unix.ads
+++ b/src/unix.ads
@@ -74,7 +74,7 @@ package Unix is
    function create_hardlink (actual_file : String; destination : String) return Boolean;
 
    --  Attempts to create a symlink and returns True on success
-   function create_symlink (actual_file : String; destination : String) return Boolean;
+   function create_symlink (actual_file : String; link_to_create : String) return Boolean;
 
 private
 


### PR DESCRIPTION
Switch packages mount to readonly.
In order to accomplish this, build package archive files have to be moved from outside the
chroot instead of internally.